### PR TITLE
Fix return code when match is not found

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -83,6 +83,10 @@ def basic_test():
     data = gen_padded_data(offsets, pattern)
     single_test(data, pattern, offsets)
 
+def no_find():
+    data = 'notherenotgonnafindit'
+    single_test(data, 'HOLYGRAIL', [], retcode=1)
+
 def multiple_offsets():
     offsets = [4, 27, 369, 630, 750]
     pattern = '\x12\x34\x56\x78'
@@ -96,6 +100,7 @@ def no_overlap():
 
 all_tests = [
     basic_test,
+    no_find,
     multiple_offsets,
     no_overlap,
 ]


### PR DESCRIPTION
Like grep, bgrep should return 1 when no match is found, and 0 when at least one match was found.
